### PR TITLE
Confirm token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,7 @@ doc:
 clean:
 	rm -rf docs
 
-.PHONY: doc clean
+all:
+	make doc && make clean
+
+.PHONY: doc clean all

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,6 +92,7 @@ func main() {
 			offers.Use(middleware.Auth())
 			offers.GET("/", handlers.OfferHandlerGet)
 			offers.GET("/:id/", handlers.OfferHandlerGetId)
+			offers.POST("/confirm/", handlers.OfferConfirmHandlerPost)
 		}
 	}
 

--- a/cmd/swagger.yml
+++ b/cmd/swagger.yml
@@ -131,6 +131,19 @@ paths:
       summary: Get an offer
       tags:
       - Offers
+  /v1/offers/confirm/:
+    post:
+      consumes:
+      - application/json
+      description: Confirm an offer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Create a new interest
+      tags:
+      - Offer
   /v1/signup/:
     post:
       consumes:

--- a/internal/models/offer.go
+++ b/internal/models/offer.go
@@ -1,19 +1,49 @@
 package models
 
 import (
+	"errors"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // Offer model
 type Offer struct {
-	Id        uint      `gorm:"column:id" json:"id"`
-	CreatedAt time.Time `gorm:"column:created_at" json:"created_at"`
-	Message   string    `gorm:"column:message" json:"message"`
-	Expired   string    `gorm:"column:expired" json:"expired"`
-	Token     string    `gorm:"column:token" json:"token"`
-	IsUsed    bool      `gorm:"column:is_used" json:"is_user"`
-	JourneyId int       `json:"-"`
-	Journey   Journey   `gorm:"foreignKey:JourneyId" json:"journey"`
-	UserId    *int      `json:"-"`
-	User      *User     `gorm:"foreignKey:UserId" json:"user"`
+	Id          uint      `gorm:"column:id" json:"id"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"created_at"`
+	Message     string    `gorm:"column:message" json:"message"`
+	Expired     string    `gorm:"column:expired" json:"expired"`
+	Token       string    `gorm:"column:token" json:"token"`
+	IsUsed      bool      `gorm:"column:is_used" json:"is_used"`
+	PaymentLink string    `gorm:"column:payment_link" json:"payment_link"`
+	PaymentPaid bool      `gorm:"column:payment_paid" json:"payment_paid"`
+	JourneyId   int       `json:"-"`
+	Journey     Journey   `gorm:"foreignKey:JourneyId" json:"journey"`
+	UserId      *int      `json:"-"`
+	User        *User     `gorm:"foreignKey:UserId" json:"user"`
+}
+
+// Offer struct used to confirm a token
+type OfferConfirmInput struct {
+	Token string `binding:"required"`
+}
+
+// Validates an offer token
+func ValidateOfferToken(db *gorm.DB, in OfferConfirmInput, userId uint) error {
+	var user User
+
+	if err := db.Where("id = ?", userId).First(&user).Error; err != nil {
+		return errors.New("`user_id` does not exist.")
+	}
+
+	var offer Offer
+	if err := db.Where("token = ?", in.Token).First(&offer).Error; err != nil {
+		return errors.New("`token` does not exist.")
+	}
+
+	if !(user.IsAdmin || int(user.Id) == *offer.UserId) {
+		return errors.New("`token` does not exist.")
+	}
+
+	return nil
 }


### PR DESCRIPTION
A new offer has a response like this below:

```json
{
    "id": 81,
    "created_at": "2024-05-24T17:41:14.917591+02:00",
    "message": "...",
    "expired": "1716651674",
    "token": "UZFWYT",
    "is_used": false,
    "payment_link": "",
    "payment_paid": false,
    "journey": {
        "id": 55,
...
}
```

----

You must pass a header `Authorization: Bearer <token_from_login>` for each of them.

# POST `/v1/offers/confirm/`

- Request

```json
{
	"token": "..."
}
```

- Response

200 OK

Now, if you check again the offer you'll see

```json
{
    "id": 81,
    "created_at": "2024-05-24T17:41:14.917591+02:00",
    "message": "...",
    "expired": "1716651674",
    "token": "UZFWYT",
    "is_used": true,
    "payment_link": "http://localhost:5173/?id=99d378c6-da03-4b4a-aaf2-c2fdb3c3f580",
    "payment_paid": false,
    "journey": {
        "id": 55,
...
}
```

so you have to show that `payment_link` to the user